### PR TITLE
Replace `distutils` with `packaging` for version checking

### DIFF
--- a/pelican/plugins/render_math/math.py
+++ b/pelican/plugins/render_math/math.py
@@ -265,11 +265,11 @@ def configure_typogrify(pelicanobj, mathjax_settings):
         return
 
     try:
-        from distutils.version import LooseVersion
+        from packaging.version import Version
 
         import typogrify
 
-        if LooseVersion(typogrify.__version__) < LooseVersion("2.0.7"):
+        if Version(typogrify.__version__) < Version("2.0.7"):
             raise TypeError("Incorrect version of Typogrify")
 
         from typogrify.filters import typogrify


### PR DESCRIPTION
`distutils` has been removed from python 3.12.  This is causing an ImportError in `configure_typogrify` which then inadvertently disables Typogrify.  This updates to `packaging.version.Version`.  