### PR TITLE
Process hidden articles and translations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add the MathJax script to hidden articles and translations.

--- a/pelican/plugins/render_math/math.py
+++ b/pelican/plugins/render_math/math.py
@@ -382,16 +382,15 @@ def process_rst_and_summaries(content_generators):
     for generator in content_generators:
         if isinstance(generator, generators.ArticlesGenerator):
             for article in (
-                generator.articles + generator.translations + generator.drafts
+                generator.articles + generator.translations + generator.drafts + \
+                generator.hidden_articles + generator.hidden_translations
             ):
                 rst_add_mathjax(article)
                 # optionally fix truncated formulae in summaries.
                 if process_summary.mathjax_script is not None:
                     process_summary(article)
         elif isinstance(generator, generators.PagesGenerator):
-            for page in generator.pages:
-                rst_add_mathjax(page)
-            for page in generator.hidden_pages:
+            for page in (generator.pages + generator.hidden_pages):
                 rst_add_mathjax(page)
 
 


### PR DESCRIPTION
The MathJax script was added to hidden pages, but not to hidden _articles_ (or translations). This fixes it.